### PR TITLE
1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 build/
 dist/
 MANIFEST
-run_tests.py

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Python client library for interacting with the SIS RESTful API.
 - [LICENSE](#license)
   
 # Dependencies
-- Python 2.6 - 3.4
+- Python 2.6+, 3.4+
 
 The client will work using the standard library only, however, if Requests(https://pypi.python.org/pypi/requests/) *v2+* is installed, it will automatically attempt to use it in order to siginificantly improve it's performance.
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ Python client library for interacting with the SIS RESTful API.
 # Dependencies
 - Python 2.6 - 3.4
 
-The client will work using the standard library only, however, if the bellow packages are installed, it will automatically attempt to use them in order to siginificantly improve it's performance:
-- requests (https://pypi.python.org/pypi/requests/)
-- ujson (https://pypi.python.org/pypi/ujson)
+The client will work using the standard library only, however, if Requests(https://pypi.python.org/pypi/requests/) *v2+* is installed, it will automatically attempt to use it in order to siginificantly improve it's performance.
 
 # Installation
 

--- a/examples/run_tests.py
+++ b/examples/run_tests.py
@@ -1,0 +1,34 @@
+"""
+SIS Python client tests
+
+This needs to be ran with requests installed and without it.
+"""
+import getpass
+import logging
+import unittest
+
+from sispy.testsuite import Test
+
+# set up logging
+console_handler = logging.StreamHandler()
+console_handler.setFormatter(
+    logging.Formatter(
+        '%(asctime)s:%(module)s:'
+        '%(levelname)s:%(message)s'))
+logging.getLogger().addHandler(console_handler)
+logging.getLogger().setLevel(logging.DEBUG)
+
+username = getpass.getuser()
+password = getpass.getpass()
+
+# init Test()
+t = Test(
+    url='https://sis.myorg.com',
+    username=username,
+    password=password,
+    owner='ops'
+)
+
+# run tests
+unittest.TextTestRunner().run(t)
+

--- a/sispy/__init__.py
+++ b/sispy/__init__.py
@@ -2,7 +2,7 @@
 
 """Client library for interacting with the SIS RESTful API"""
 
-__version__ = (0, 4, 3)
+__version__ = (0, 4, 4)
 __author__ = 'Anton Gavrik'
 
 import logging

--- a/sispy/__init__.py
+++ b/sispy/__init__.py
@@ -2,8 +2,10 @@
 
 """Client library for interacting with the SIS RESTful API"""
 
-__version__ = (0, 4, 4)
+__version__ = (1, 0, 0)
 __author__ = 'Anton Gavrik'
+
+import json
 
 import logging
 try:  # Python 2.7+
@@ -16,11 +18,6 @@ except ImportError:
 LOG = logging.getLogger(__name__)
 LOG.addHandler(NullHandler())
 
-# attempt to use ujson to handle json, fall back to stdlib json if unavailable
-try:
-    import ujson as json
-except ImportError:
-    import json
 
 class Response(object):
     """Represent the client's response.
@@ -79,6 +76,7 @@ class Response(object):
                 self.__class__.__name__))
         return list(self._result)
 
+
 class Meta(object):
     """Represents meta data in the clients response."""
 
@@ -96,6 +94,7 @@ class Meta(object):
 
         if 'x-total-count' in self.headers:
             self.total_count = int(self.headers['x-total-count'])
+
 
 class Error(Exception):
     """SIS Error"""
@@ -128,6 +127,7 @@ class Error(Exception):
 
     def __str__(self):
         return self.error
+
 
 from .client import Client
 

--- a/sispy/client.py
+++ b/sispy/client.py
@@ -8,6 +8,7 @@ from . import http, endpoint, NullHandler
 LOG = logging.getLogger(__name__)
 LOG.addHandler(NullHandler())
 
+
 class Client(object):
 
     """SIS client"""

--- a/sispy/endpoint.py
+++ b/sispy/endpoint.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 
 import logging
+import json
 
-from . import Error, Response, http, json, NullHandler
+from . import Error, Response, http, NullHandler
 
 LOG = logging.getLogger(__name__)
 LOG.addHandler(NullHandler())
+
 
 class Endpoint(object):
 

--- a/sispy/http.py
+++ b/sispy/http.py
@@ -8,14 +8,16 @@ from . import json, Response, Error, Meta, NullHandler
 LOG = logging.getLogger(__name__)
 LOG.addHandler(NullHandler())
 
-# attempt to use requests by default, if not available fall back to the 
-# standard library
+# attempt to use requests v2+ if available
+# if not, fall back to the standard library
+HTTP_LIB = 'stdlib'
 try:
     import requests
 except ImportError:
-    HTTP_LIB = 'stdlib'
+    pass
 else:
-    HTTP_LIB = 'requests'
+    if requests.__version__.split('.')[0] >= 2:
+        HTTP_LIB = 'requests'
 
 if HTTP_LIB == 'stdlib':
     # for versions 2.7.9+ and 3.4.3+ we need unverified SSL context to disable

--- a/sispy/http.py
+++ b/sispy/http.py
@@ -2,22 +2,23 @@
 
 import logging
 import sys
+import json
 
-from . import json, Response, Error, Meta, NullHandler
+from . import Response, Error, Meta, NullHandler
 
 LOG = logging.getLogger(__name__)
 LOG.addHandler(NullHandler())
 
-# attempt to use requests v2+ if available
-# if not, fall back to the standard library
+# use the standard library by default,
+# but use requests v2+ if available
 HTTP_LIB = 'stdlib'
 try:
     import requests
-except ImportError:
-    pass
-else:
     if requests.__version__.split('.')[0] >= 2:
         HTTP_LIB = 'requests'
+except Exception:
+    pass
+LOG.debug('using {0} to handle http'.format(HTTP_LIB))
 
 if HTTP_LIB == 'stdlib':
     # for versions 2.7.9+ and 3.4.3+ we need unverified SSL context to disable
@@ -59,6 +60,7 @@ else:
     import urllib
     urlencode = urllib.urlencode
 
+
 def get_handler(http_keep_alive=True):
     """Returns an appropriate http handler object based on the available 
     http library.
@@ -69,6 +71,7 @@ def get_handler(http_keep_alive=True):
 
     elif HTTP_LIB == 'requests':
         return RequestsHandler(http_keep_alive=http_keep_alive)
+
 
 class Request(object):
 
@@ -86,6 +89,7 @@ class Request(object):
         s += '{0} '.format(self.uri)
         return s
 
+
 class BaseHTTPHandler(object):
 
     """HTTP Handler proxy base class"""
@@ -95,6 +99,7 @@ class BaseHTTPHandler(object):
 
     def request(self, request):
         raise NotImplementedError
+
 
 class StdLibHandler(BaseHTTPHandler):
 
@@ -132,7 +137,17 @@ class StdLibHandler(BaseHTTPHandler):
                 response = stdlib_urlopen(new_req)
 
         except stdlib_HTTPError as e:
-            response_dict = json.loads(e.read().decode('utf-8'))
+            # read response
+            response_str = e.read().decode('utf-8')
+
+            # decode response, trap non-json responses
+            try:
+                response_dict = json.loads(response_str)
+            except ValueError:
+                raise Error(http_status_code=e.code,
+                            error=('Received a non-json response: {0}'
+                            .format(response_str[:256].encode('utf-8'))))
+                                                            
             code = response_dict.get('code')
 
             # lookup error in the response body,
@@ -147,7 +162,15 @@ class StdLibHandler(BaseHTTPHandler):
                         response_dict=response_dict)
 
         # read response
-        result = json.loads(response.read().decode('utf-8'))
+        response_str = response.read().decode('utf-8')
+
+        # decode response, trap non-json responses
+        try:
+            result = json.loads(response_str)
+        except ValueError:
+            raise Error(http_status_code=response.getcode(),
+                        error=('Received a non-json response: {0}'
+                        .format(response_str[:256].encode('utf-8'))))
 
         # build meta with headers as a dict
         # py3
@@ -164,6 +187,7 @@ class StdLibHandler(BaseHTTPHandler):
 
         # return Response object    
         return Response(result, meta)
+
 
 class RequestsHandler(BaseHTTPHandler):
 
@@ -194,8 +218,13 @@ class RequestsHandler(BaseHTTPHandler):
         # verify=False do not verify SSL cert
         response = self._session.send(prepped, stream=True, verify=False)
 
-        # we always expect a json body
-        response_dict = json.loads(response.text)
+        # decode response, trap non-json responses
+        try:
+            response_dict = json.loads(response.text)
+        except ValueError:
+            raise Error(http_status_code=response.status_code,
+                        error=('Received a non-json response: {0}'
+                        .format(response.text[:256].encode('utf-8'))))
 
         # raise Error if we got http status code >= 400
         if response.status_code >= 400:


### PR DESCRIPTION
- only use requests version 2+
- remove support for ujson
- trap non-json responses, sispy.Error.error is set to up to 256 first chars of such a response
